### PR TITLE
feat : 상품상세에서 인원 추가 옵션 체크 추가.

### DIFF
--- a/src/main/java/com/toucheese/product/dto/AddOptionResponse.java
+++ b/src/main/java/com/toucheese/product/dto/AddOptionResponse.java
@@ -3,19 +3,23 @@ package com.toucheese.product.dto;
 import com.toucheese.product.entity.ProductAddOption;
 
 import lombok.Builder;
+import java.util.Set;
 
 @Builder
 public record AddOptionResponse(
 	Long id,
 	Integer price,
-	String name
+	String name,
+	Integer isPlusOpt
 ) {
+	private static final Set<Long> PLUS_OPTION_IDS = Set.of(61L, 80L, 93L, 97L, 109L, 137L, 142L, 143L, 163L, 168L, 171L);
 
 	public static AddOptionResponse of(ProductAddOption productAddOption) {
 		return AddOptionResponse.builder()
 			.id(productAddOption.getAddOption().getId())
 			.name(productAddOption.getAddOption().getAddOptionName())
 			.price(productAddOption.getAddOptionPrice())
+			.isPlusOpt(PLUS_OPTION_IDS.contains(productAddOption.getAddOption().getId()) ? 1 : 0)
 			.build();
 	}
 }


### PR DESCRIPTION
이제 상품 상세 조회 API를 호출하면:
추가 옵션의 ID가 61, 80, 93, 97, 109, 137, 142, 143, 163, 168, 171 중 하나일 경우 isPlusOpt 값이 1로 설정됩니다.
다른 ID의 경우에는 isPlusOpt 값이 0으로 설정됩니다.
![스크린샷 2025-05-27 오전 11 26 59](https://github.com/user-attachments/assets/b445c4c0-fc6e-43de-99ee-974f6cb9d2e4)
