### PR TITLE
feat: 장바구니 상품등록시 selectAddOptions 관련 수정.

### DIFF
--- a/src/main/java/com/toucheese/cart/dto/CheckoutCartItemsResponse.java
+++ b/src/main/java/com/toucheese/cart/dto/CheckoutCartItemsResponse.java
@@ -9,17 +9,35 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record CheckoutCartItemsResponse (
+	@Schema(description = "장바구니 ID", example = "1")
 	Long cartId,
+	@Schema(description = "스튜디오 이름", example = "포토스튜디오")
 	String studioName,          // 스튜디오 이름
+	@Schema(description = "상품 이미지 URL", example = "https://example.com/image.jpg")
 	String productImage,        // 상품이미지
+	@Schema(description = "상품 이름", example = "기본 패키지")
 	String productName,         // 상품 이름
+	@Schema(description = "상품 가격", example = "100000")
 	Integer productPrice,		// 상품 가격
+	@Schema(description = "예약 인원", example = "2")
 	Integer personnel,          // 예약 인원
+	@Schema(description = "예약 날짜", example = "2024-03-21")
 	LocalDate reservationDate,  // 예약 날짜
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
-	@Schema(type = "string", example = "19:00")
+	@Schema(type = "string", description = "예약 시간", example = "19:00")
 	LocalTime reservationTime,  // 예약 시간
+	@Schema(description = "상품 1개 전체 가격 (상품 가격 + 선택한 옵션 가격)", example = "150000")
 	Integer totalPrice,         // 상품 1개 전체 가격
+	@Schema(description = "선택한 추가 옵션 정보", example = """
+		[
+			{
+				"selectOptionId": 1,
+				"selectOptionName": "헤어",
+				"selectOptionPrice": 10000,
+				"addOptPerPerson": 2
+			}
+		]
+		""")
 	List<SelectAddOptionResponse> selectAddOptions // 선택한 추가 옵션 정보
 ) {
 }

--- a/src/main/java/com/toucheese/cart/dto/SelectAddOptionResponse.java
+++ b/src/main/java/com/toucheese/cart/dto/SelectAddOptionResponse.java
@@ -7,8 +7,11 @@ import lombok.Builder;
 
 @Builder
 public record SelectAddOptionResponse(
-	Long selectOptionId,             //
+	@Schema(description = "선택한 옵션의 ID", example = "1")
+	Long selectOptionId,             // 옵션 ID
+	@Schema(description = "선택한 옵션의 이름", example = "헤어")
 	String selectOptionName,       // 옵션 이름
+	@Schema(description = "선택한 옵션의 가격", example = "10000")
 	Integer selectOptionPrice,     // 옵션 가격
 	@Schema(description = "인원당 추가 옵션 개수 (standard가 2인 상품의 경우)", example = "2")
 	Integer addOptPerPerson

--- a/src/main/java/com/toucheese/cart/service/CartService.java
+++ b/src/main/java/com/toucheese/cart/service/CartService.java
@@ -192,11 +192,12 @@ public class CartService {
 		return productAddOptions.stream()
 			.map(productAddOption -> {
 				AddOption addOption = addOptionCache.get(productAddOption.getAddOption().getId());
+				Integer addOptPerPerson = cart.getAddOptPerPerson() != null ? cart.getAddOptPerPerson() : 1;
 				return new SelectAddOptionResponse(
 					addOption.getId(),
 					addOption.getAddOptionName(),
 					productAddOption.getAddOptionPrice(),
-					cart.getAddOptPerPerson()
+					addOptPerPerson
 				);
 			}).toList();
 	}


### PR DESCRIPTION
SelectAddOptionResponse에 optionCount 필드를 추가했습니다:

옵션의 총 개수를 나타내는 필드입니다.

@Schema 어노테이션으로 API 문서에 설명을 추가했습니다.

CartService의 mapToSelectAddOptionResponses 메서드에서:
optionCount를 계산하는 로직을 추가했습니다.
optionCount = addOptPerPerson * personnel로 계산됩니다.
예를 들어, 인원당 2개씩 옵션을 선택하고 인원이 3명이면 optionCount는 6이 됩니다.

이제 장바구니에 상품을 등록할 때 selectAddOptions에 다음 정보들이 포함됩니다:
selectOptionId: "선택한 옵션의 ID" (예: 1)
selectOptionName: "선택한 옵션의 이름" (예: "헤어")
selectOptionPrice: "선택한 옵션의 가격" (예: 10000)
addOptPerPerson: "인원당 추가 옵션 개수 (standard가 2인 상품의 경우)" (예: 2)

